### PR TITLE
using Gem::Version.new for valid semver

### DIFF
--- a/get_data.rb
+++ b/get_data.rb
@@ -14,7 +14,7 @@ def get_cookbook_list(endpoint)
   cookbooks = endpoint.get_rest('/cookbooks?num_versions=all')
   cookbooks.each do |name, data|
     data['versions'].each do |version_hash|
-      version = version_hash['version']
+      version = Gem::Version.new(version_hash['version']).to_s
       if cb_list[name] && !cb_list[name].include?(version)
         cb_list[name].push(version)
       else
@@ -88,7 +88,7 @@ orgs.each do |org|
   #nodes[0].select{|node| node.class == Array}.each do |node|
   nodes[0].select{|node| !node['cookbooks'].nil?}.each do |node|
     node['cookbooks'].each do |name, version_hash|
-      version = version_hash['version']
+      version = Gem::Version.new(version_hash['version']).to_s
       if used_cookbooks[name] && !used_cookbooks[name].include?(version)
         used_cookbooks[name].push(version)
       else


### PR DESCRIPTION
This should fix #3 

It looks like the array containing versions contains `nil` so you get the `comparison of String with nil failed` error:

```
irb(main):001:0> used_list = {}
=> {}
irb(main):002:0> used_list['runit'] = ['5.0.0', '1.3.2', nil]
=> ["5.0.0", "1.3.2", nil]
irb(main):003:0> used_list['runit'].sort
ArgumentError: comparison of String with nil failed
	from (irb):3:in `sort'
	from (irb):3
	from /opt/chefdk/embedded/bin/irb:11:in `<main>'
irb(main):004:0>
```

`Gem::Version.new(nil)` will result in `''` which is safe for sort:
```
irb(main):006:0> versions = [Gem::Version.new('5.2.2').to_s, Gem::Version.new(nil).to_s]
=> ["5.2.2", ""]
irb(main):007:0>
```

Signed-off-by: Jeremy J. Miller <jm@chef.io>