### PR TITLE
fixed threshold_days option

### DIFF
--- a/get_data.rb
+++ b/get_data.rb
@@ -96,7 +96,7 @@ orgs.each do |org|
       end
     end
   end
-  threshold_in_days = 30
+  threshold_in_days = options[:threshold_days].to_i || 30
   stale_nodes = []
   nodes[0].each do |n|
     if (Time.now.to_i - n['ohai_time'].to_i) >= threshold_in_days * 86400


### PR DESCRIPTION
Threshold argument (--node-threshold) was not being honored and forced to 30 days.  Changed to default to 30 days, but accept the command line option.